### PR TITLE
백엔드 엔드포인트 변경에 따른 수정

### DIFF
--- a/src/app/(routes)/mover/(main)/quotes/(myQuotes)/submitted/page.tsx
+++ b/src/app/(routes)/mover/(main)/quotes/(myQuotes)/submitted/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react';
 
 export default function Page() {
   return (
-    <div className='w-full bg-backgroundVariants-100 h-full py-10'>
+    <div className='flex w-full bg-backgroundVariants-100 flex-1 py-10'>
       <Suspense fallback={<div>Loading...</div>}>
         <SubmittedQuotesByMover />
       </Suspense>

--- a/src/app/(routes)/mover/(main)/quotes/[id]/page.tsx
+++ b/src/app/(routes)/mover/(main)/quotes/[id]/page.tsx
@@ -7,7 +7,7 @@ import ShareButtons from '@/components/common/ShareButtons';
 import CustomerInfo from '@/components/common/customerInfo/templates/customerInfo';
 import QuoteCard from '@/components/quoteCard/molecules/quoteCard';
 import { useQuery } from '@tanstack/react-query';
-import { getQuoteByMover } from '@/services/quotes';
+import { getQuoteByMover } from '@/services/moverQuotes';
 import { useMemo } from 'react';
 import { MOVING_TYPES } from '@/constants/movingTypes';
 

--- a/src/app/(routes)/user/(main)/quotes/[id]/page.tsx
+++ b/src/app/(routes)/user/(main)/quotes/[id]/page.tsx
@@ -8,7 +8,7 @@ import PageHeader from '@/components/common/shared/atoms/pageHeader';
 import ShareButtons from '@/components/common/ShareButtons';
 import QuoteCard from '@/components/quoteCard/molecules/quoteCard';
 import { useQuery } from '@tanstack/react-query';
-import { getQuoteByCustomer } from '@/services/quotes';
+import { getQuoteByCustomer } from '@/services/moverQuotes';
 import { MOVING_TYPES } from '@/constants/movingTypes';
 import { useMemo } from 'react';
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
   return (
     <QueryProvider>
       <html lang='Ko'>
-        <body className={`${pretendard.variable} antialiased`}>
+        <body
+          className={`${pretendard.variable} antialiased h-screen flex flex-col`}
+        >
           <GNB
             isUserAuthorized={true}
             userType='user'

--- a/src/components/quoteRequest/QuoteConfirmationModal.tsx
+++ b/src/components/quoteRequest/QuoteConfirmationModal.tsx
@@ -6,7 +6,7 @@ import { maxStep } from './QuoteRequestPage';
 import formatKoreanTime from '@/utils/formatKoreanTime';
 import service from '@/constants/dropdown/service';
 import axiosInstance from '@/lib/axiosInstance';
-import { createQuoteRequest } from '@/services/quotes';
+import { createQuoteRequest } from '@/services/moverQuotes';
 
 interface QuoteConfirmationModalProps {
   setShowModal: (value: boolean) => void;

--- a/src/components/submittedQuotesByMover/index.tsx
+++ b/src/components/submittedQuotesByMover/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import CustomerInfo from '@/components/common/customerInfo/templates/customerInfo';
-import { getSubmittedQuotesList } from '@/services/quotes';
+import { getSubmittedQuotesList } from '@/services/moverQuotes';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Pagination from '../pagination/molecule/pagination';

--- a/src/components/submittedQuotesByMover/index.tsx
+++ b/src/components/submittedQuotesByMover/index.tsx
@@ -3,41 +3,53 @@
 import CustomerInfo from '@/components/common/customerInfo/templates/customerInfo';
 import { getSubmittedQuotesList } from '@/services/quotes';
 import { useQuery } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Pagination from '../pagination/molecule/pagination';
 
 export default function SubmittedQuotesByMover() {
   const searchParams = useSearchParams();
   const page = Number(searchParams.get('page') || 1);
-  const pageSize = Number(searchParams.get('pageSize') || 4);
-  const moverId = 'cm8cvdyaf006lt47dywv5gugh';
+  const pageSize = 6;
+  const router = useRouter();
 
   const { data } = useQuery({
     queryKey: ['quotes', page, pageSize],
-    queryFn: async () => getSubmittedQuotesList({ page, pageSize, moverId }),
+    queryFn: async () => getSubmittedQuotesList({ page, pageSize }),
   });
+
+  const onPageChange = (page: number) => {
+    router.push(`?page=${page}`);
+  };
 
   return (
     data && (
-      <div className='w-full bg-backgroundVariants-100 h-full py-10'>
-        <div className='grid grid-cols-1 md:grid-cols-1 xl:grid-cols-2 max-w-[1400px] px-6 md:px-[72px] xl:px-0 mx-auto gap-[24px] gap-y-12'>
-          {data.list.map((quote) => (
-            <CustomerInfo
-              key={quote.customerName}
-              quoteId={quote.id}
-              variant='submitted'
-              movingType={[quote.request.moveType]}
-              quoteState={quote.matched ? 'confirmedQuote' : 'pendingQuote'}
-              isCustomQuote={quote.isCustomRequest}
-              customerName={quote.customerName}
-              movingDate={quote.request.moveDate}
-              arrival={quote.request.arrival.sido}
-              departure={quote.request.departure.sido}
-              completed={quote.completed}
-              declined={false}
-              quotePrice={quote.price}
-            />
-          ))}
+      <div className='w-full flex items-center flex-col gap-10'>
+        <div className='grid grid-cols-1 md:grid-cols-1 xl:grid-cols-2 max-w-[1400px] w-full px-6 md:px-[72px] xl:px-0 mx-auto gap-[24px] gap-y-12'>
+          {data.list.map((quote) => {
+            return (
+              <CustomerInfo
+                key={quote.customerName}
+                quoteId={quote.id}
+                variant='submitted'
+                movingType={[quote.request.moveType]}
+                quoteState={quote.matched ? 'confirmedQuote' : 'pendingQuote'}
+                isCustomQuote={quote.isCustomRequest}
+                customerName={quote.customerName}
+                movingDate={quote.request.moveDate}
+                arrival={quote.request.arrival.sido}
+                departure={quote.request.departure.sido}
+                completed={quote.completed}
+                declined={false}
+                quotePrice={quote.price}
+              />
+            );
+          })}
         </div>
+        <Pagination
+          currentPage={page}
+          totalPages={data.totalPages}
+          onPageChange={onPageChange}
+        />
       </div>
     )
   );

--- a/src/services/moverQuotes.ts
+++ b/src/services/moverQuotes.ts
@@ -6,10 +6,12 @@ import {
 import { QuoteRequest } from './types/quotesDetail/common.types';
 import { SubmittedQuotes } from './types/submittedQuotes/submittedQuotes.types';
 
+const MOVER_QUOTE_URL = '/mover-quotes';
+
 export const getQuoteByCustomer = async (quoteId: string) => {
   try {
     const { data } = await axiosInstance.get<QuoteForCustomer>(
-      `/quotes/${quoteId}/customer`,
+      `${MOVER_QUOTE_URL}/${quoteId}/customer`,
     );
     return data;
   } catch {
@@ -20,7 +22,7 @@ export const getQuoteByCustomer = async (quoteId: string) => {
 export const getQuoteByMover = async (quoteId: string) => {
   try {
     const { data } = await axiosInstance.get<QuoteForMover>(
-      `/quotes/${quoteId}/mover`,
+      `${MOVER_QUOTE_URL}${quoteId}/mover`,
     );
     return data;
   } catch {
@@ -37,7 +39,7 @@ export const getSubmittedQuotesList = async ({
 }) => {
   try {
     const { data } = await axiosInstance.get<SubmittedQuotes>(
-      `/quotes/submitted`,
+      `${MOVER_QUOTE_URL}/submitted`,
       {
         params: {
           page,
@@ -58,7 +60,7 @@ export const createQuoteRequest = async ({
   arrival,
 }: QuoteRequest) => {
   try {
-    await axiosInstance.post<QuoteRequest>(`/quotes/request`, {
+    await axiosInstance.post<QuoteRequest>(`/quote-requests`, {
       moveType,
       moveDate,
       departure,

--- a/src/services/quoteRequests.ts
+++ b/src/services/quoteRequests.ts
@@ -1,0 +1,20 @@
+import axiosInstance from '@/lib/axiosInstance';
+import { QuoteRequest } from './types/quotesDetail/common.types';
+
+export const createQuoteRequest = async ({
+  moveType,
+  moveDate,
+  departure,
+  arrival,
+}: QuoteRequest) => {
+  try {
+    await axiosInstance.post<QuoteRequest>(`/quote-requests`, {
+      moveType,
+      moveDate,
+      departure,
+      arrival,
+    });
+  } catch (error: any) {
+    console.error('견적 요청 실패', error);
+  }
+};

--- a/src/services/quotes.ts
+++ b/src/services/quotes.ts
@@ -30,16 +30,14 @@ export const getQuoteByMover = async (quoteId: string) => {
 
 export const getSubmittedQuotesList = async ({
   page = 1,
-  pageSize = 4,
-  moverId,
+  pageSize = 6,
 }: {
   page: number;
   pageSize: number;
-  moverId: string;
 }) => {
   try {
     const { data } = await axiosInstance.get<SubmittedQuotes>(
-      `/quotes/${moverId}/submitted`,
+      `/quotes/submitted`,
       {
         params: {
           page,


### PR DESCRIPTION
# 백엔드 엔드포인트 변경에 따른 수정
- 기사님이 보낸 견적과 관련된 API는 /mover-quotes
- 사용자가 견적을 요청하는 API는 /quote-requests 로 변경됨
- 이에 따른 프론트엔드 API 호출 함수의 엔드포인트 수정
- 기존에 quotes에 통합되어 있던 함수들을 각각 moverQuotes,quoteRequests로 분리